### PR TITLE
Increase timeout for TestResourceManagerIsSafeForConcurrentAccessAndEnumeration

### DIFF
--- a/src/libraries/System.Resources.Extensions/tests/BinaryResourceWriterUnitTest.cs
+++ b/src/libraries/System.Resources.Extensions/tests/BinaryResourceWriterUnitTest.cs
@@ -528,7 +528,7 @@ namespace System.Resources.Extensions.Tests
             using Barrier barrier = new(Threads);
             Task task = Task.WhenAll(Enumerable.Range(0, Threads).Select(_ => Task.Run(WaitForBarrierThenEnumerateResources)));
 
-            Assert.True(task.Wait(TimeSpan.FromSeconds(10)));
+            Assert.True(task.Wait(TimeSpan.FromSeconds(30)));
 
             void WaitForBarrierThenEnumerateResources()
             {


### PR DESCRIPTION
This raises the timeout to 30s, the same as what we have for the equivalent ResourceManager test (https://github.com/dotnet/runtime/blob/15fcb990fe17348ab6ddde0939200b900169920b/src/libraries/System.Resources.ResourceManager/tests/ResourceManagerTests.cs#L255).

(hopefully) fix #80277